### PR TITLE
Change to avoid warning message

### DIFF
--- a/knmi/knmi.py
+++ b/knmi/knmi.py
@@ -97,9 +97,9 @@ def get_day_data_dataframe(stations, start=None, end=None, inseason=False, varia
                                                           variables=variables)
 
     df = parse_dataframe(data=data)
-    df.legend = legend
-    df.stations = stations
-    df.disclaimer = disclaimer
+    df['legend'] = legend
+    df['stations'] = stations
+    df['disclaimer'] = disclaimer
 
     return df
 


### PR DESCRIPTION
In Jupyter, I get the error message: 'Pandas doesn't allow columns to be created via a new attribute name'. According to StackOverflow this should be solved with the proposed changes.